### PR TITLE
Removed setting _id to false on player schema

### DIFF
--- a/src/schemas/player.schema.ts
+++ b/src/schemas/player.schema.ts
@@ -3,7 +3,6 @@ import { Document } from 'mongoose';
 
 @Schema({
   timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' },
-  _id: false,
 })
 export class Player extends Document {
   @Prop({


### PR DESCRIPTION
Top level documents must have an _id value so removed _id: false which prevented players from being saved